### PR TITLE
Update copyright and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Solid
+Copyright 2023 W3C Solid Community Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -349,17 +349,6 @@
             </dd>
           </dl>
 
-          <dl id="document-license">
-            <dt>License</dt>
-            <dd>
-              <a
-                href="http://purl.org/NET/rdflicense/MIT1.0"
-                rel="schema:license"
-                >MIT License</a
-              > but <b>all code snippets are in the public domain</b>, CC0.
-            </dd>
-          </dl>
-
           <dl id="document-status">
             <dt>Document Status</dt>
             <dd
@@ -397,17 +386,17 @@
                 <dt>Unique Identifier</dt>
                 <dd>
                   <a
-                    href="https://solidproject.org/TR/chat#document-policy-offer"
+                    href="https://solid.github.io/chat/#document-policy-offer"
                     rel="odrl:uid"
-                    >https://solidproject.org/TR/chat#document-policy-offer</a
+                    >https://solid.github.io/chat/#document-policy-offer</a
                   >
                 </dd>
                 <dt>Target</dt>
                 <dd>
                   <a
-                    href="https://solidproject.org/TR/chat"
+                    href="https://solid.github.io/chat/"
                     rel="odrl:target"
-                    >https://solidproject.org/TR/chat</a
+                    >https://solid.github.io/chat/</a
                   >
                 </dd>
                 <dt>Permission</dt>
@@ -422,8 +411,8 @@
                     <dd>
                       <a
                         rel="odrl:assigner"
-                        href="https://github.com/solid/"
-                        >Solid Organization</a
+                        href="https://www.w3.org/groups/cg/solid"
+                        >W3C Solid Community Group</a
                       >
                     </dd>
                     <dt>Action</dt>
@@ -592,11 +581,7 @@
           </dl>
         </details>
 
-        <p class="copyright">
-          W3C License. Copyright © 2022-2023
-          <a href="http://github.com/solid/"
-          >W3C</a>. All code snippets public domain.
-        </p>
+        <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2023 the Contributors to Solid Chat specification, published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/" rel="schema:license">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. All code snippets are in the public domain, <a href="https://creativecommons.org/public-domain/cc0/" rel="schema:license">CC0</a>.</p>
 
         <div datatype="rdf:HTML" id="content" property="schema:description">
           <section id="abstract">


### PR DESCRIPTION
Action of https://github.com/solid/specification/blob/main/meetings/2023-09-27.md#chat-client-client-spec-new-work-item .

Updates copyright and license. The text is based on respec's template.

Going forward we shouldn't use "Contributors" as a separate field because it is generally covered by the group - see the copyright line and CLA. Specs are the product of many contributors, so either the list is really kept up to date or don't bother. Anything more significant than a contributor is going to be an editor or an author.

(I originally borrowed Contributors idea from some W3C specs, and introduced it into WAC, which is why some of these Solid specs are re-using, but this is all in flux and there are changes in practises at W3C.)

So, for the foreseeable future, I recommend sticking to only Editor and Author roles. I suggest @hzbarcea to follow-up on https://github.com/solid/chat/issues/2 (as also discussed in 2023-09-27) on how specifically they want to contribute, and to please make that change in the specification in a separate PR or commit, e.g., reuse template from https://solid.github.io/notifications/protocol re Authors/Editors .

---

[Preview](https://htmlpreview.github.io/?https://github.com/solid/chat/blob/255b000fb8b6fd959e2dab5dbb82b82a9da6c653/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fchat%2F4a8cc132ab10c41572f39bfb46aeb33225ffd0ad%2Findex.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fchat%2F255b000fb8b6fd959e2dab5dbb82b82a9da6c653%2Findex.html)