### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,14 +632,11 @@
 
               <p>
                 This document was published by the
-                <a href="https://solidproject.solidcommunity.net/profile/card#me"
-                  >Solid Project</a
+                <a href="https://www.w3.org/community/solid/"
+                  >Solid Community Group</a
                 >
-                as an <em>Editor’s Draft</em>. The sections that have been
-                incorporated have been reviewed following the
-                <a href="https://github.com/solid/process">Solid process</a>.
-                However, the information in this document is still subject to
-                change. You are invited to
+                as an <em>Editor’s Draft</em>. The information in this document
+                is still subject to change. You are invited to
                 <a href="https://github.com/solid/chat/issues"
                   >contribute</a
                 >


### PR DESCRIPTION
Created this PR for better awareness. Was discussed in [2023-10-18 CG meeting](https://github.com/solid/specification/blob/main/meetings/2023-10-18.md#updating-solid-eds-sotd-to-remove-solid-process).