### PR TITLE
Fix validation errors in chat-shapes.ttl

### DIFF
--- a/shapes/chat-shapes.ttl
+++ b/shapes/chat-shapes.ttl
@@ -10,12 +10,15 @@
 
 # Domain ontologies
 
+@prefix cal: <http://www.w3.org/2002/12/cal/ical#>.
 @prefix dc: <http://purl.org/dc/elements/1.1/>.
 @prefix dct: <http://purl.org/dc/terms/>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix meeting: <http://www.w3.org/ns/pim/meeting#>.
 @prefix schema: <http://schema.org/>.
 @prefix sioc: <http://rdfs.org/sioc/ns#>.
+@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ui: <http://www.w3.org/ns/ui#>.
 @prefix wf: <http://www.w3.org/2005/01/wf/flow#>.
 
 
@@ -26,7 +29,7 @@
 :LongChatShape
 	a sh:NodeShape ;
 	sh:targetClass meeting:LongChat ;
-  sh: targetSubjectsOf meeeting:message; 
+  sh:targetSubjectsOf meeting:message;
   sh:closed false ; 
   sh:ignoredProperties ();
   sh:property [
@@ -45,7 +48,7 @@ sh:property [
     [ sh:path ui:sharedPreferences ;
      sh:count 1 ],
 
-  [ sh:path  flow:participation ;
+  [ sh:path  wf:participation ;
     sh:minCount 0 ] ,
 
   [ sh:path dc:author ;
@@ -56,7 +59,7 @@ sh:property [
 
 :MessageShape a  sh:NodeShape;
     sh:targetClass schema:Message;
-    sh: targetObjectsOf meeeting:message;  # No can be other things
+    sh:targetObjectsOf meeting:message;  # No can be other things
 
     sh:closed false ; # different message systems may have all kinds of metadata 
 
@@ -84,7 +87,7 @@ sh:property [
   sh:property [
 		sh:path dct:isReplacedBy ;
         sh:message "A chat message can only have one replacement.";
-        dh:dataType schema:Message;
+        sh:datatype schema:Message;
         sh:maxCount 1;
 	];
  
@@ -98,7 +101,7 @@ sh:property [
   sh:property [
 		sh:path schema:dateDeleted ;
         sh:message "A chat message can only have one deletion date.";
-        sh:dataType xsd:dateTime;
+        sh:datatype xsd:dateTime;
         sh:maxCount 1;
 	];
 
@@ -179,16 +182,16 @@ sh:property [
 ################ Participation objects
 
 :ParticpationShape a sh:NodeShape;
-    sh:targetObjectsOf flow:participation;
+    sh:targetObjectsOf wf:participation;
 
     sh:property [
-      sh:path ical:dtstart;
+      sh:path cal:dtstart;
       sh:datatype xsd:dateTime;
       sh:count 1;
     ];
 
     sh:property [
-      sh:path flow:participant;
+      sh:path wf:participant;
       sh:count 1;
     ];
 


### PR DESCRIPTION
Fix validation errors using http://ttl.summerofcode.be/, until all errors are resolved.

Also replace `sh:dataType` with `sh:datatype` which seems to be the correct predicate.